### PR TITLE
Fix title matching for iOS devices

### DIFF
--- a/dist/lib/utils/parse.js
+++ b/dist/lib/utils/parse.js
@@ -24,8 +24,8 @@ const sanitizeURL = ({ message }) => __awaiter(this, void 0, void 0, function* (
 });
 exports.messageToString = ({ message }) => message.replace(createRegExp, '');
 exports.parseSpoilerText = ({ message }) => __awaiter(this, void 0, void 0, function* () {
-    const name = message.match(/"((?:\\.|[^"\\])*)"/);
-    const sanitize = message.replace(/\s*"((?:\\.|[^"\\])*)"\s*/, '');
+    const name = message.match(/["“]((?:\\.|[^"\\])*)[”"]/);
+    const sanitize = message.replace(/\s*["“]((?:\\.|[^"\\])*)[”"]\s*/, '');
     return {
         name: (null === name) ? '' : name[1],
         description: yield sanitizeURL({ message: sanitize })

--- a/src/lib/utils/parse.ts
+++ b/src/lib/utils/parse.ts
@@ -31,7 +31,7 @@ export const messageToString = ({ message }: Util): string => message.replace(cr
 
 export const parseSpoilerText = async ({ message }: Util): Promise<SpoilerInfo> => {
     const name = message.match(/["“]((?:\\.|[^"\\])*)[”"]/);
-    const sanitize = message.replace(/\s*"((?:\\.|[^"\\])*)"\s*/, '');
+    const sanitize = message.replace(/\s*["“]((?:\\.|[^"\\])*)[”"]\s*/, '');
 
     return {
         name: (null === name) ? '' : name[ 1 ],


### PR DESCRIPTION
Add missing support to the left/right double quotation marks used by iOS devices.
Now spoiler names can be written either in "" or in “”.
Previous commit was incomplete.